### PR TITLE
rollup: rollup three features in one PR

### DIFF
--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use async_trait::async_trait;
 use rat_widget::focus::HasFocus;
 use ratatui::buffer::Buffer;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     },
 };
 use crossterm::{
-    event::{EventStream, KeyboardEnhancementFlags, PushKeyboardEnhancementFlags},
+    event::{EventStream, KeyEvent, KeyboardEnhancementFlags, PushKeyboardEnhancementFlags},
     execute,
 };
 use futures::{StreamExt, future::FutureExt};
@@ -249,6 +249,17 @@ impl App {
     }
     #[instrument(skip(self))]
     async fn handle_event(&mut self, event: &crossterm::event::Event) -> Result<(), AppError> {
+        use crossterm::event::Event::Key;
+        use crossterm::event::KeyCode::*;
+        use rat_widget::event::ct_event;
+        if matches!(
+            event,
+            ct_event!(key press CONTROL-'c') | ct_event!(key press CONTROL-'q')
+        ) {
+            self.cancel_action.cancel();
+            return Ok(());
+        }
+
         let capture_focus = self
             .components
             .iter()
@@ -257,14 +268,14 @@ impl App {
         let outcome = focus.handle(event, Regular);
         info!(outcome = ?outcome, "Focus");
         if let Outcome::Continue = outcome
-            && let crossterm::event::Event::Key(key) = event
+            && let Key(key) = event
             && !capture_focus
         {
             self.handle_key(key).await?;
         }
-        if let crossterm::event::Event::Key(key) = event {
+        if let Key(key) = event {
             match key.code {
-                crossterm::event::KeyCode::Char(char)
+                Char(char)
                     if ('1'..'5').contains(&char)
                         && !self
                             .components
@@ -289,7 +300,17 @@ impl App {
         Ok(())
     }
     async fn handle_key(&mut self, key: &crossterm::event::KeyEvent) -> Result<(), AppError> {
-        if matches!(key.code, crossterm::event::KeyCode::Char('q')) {
+        use crossterm::event::KeyCode::*;
+        if matches!(key.code, Char('q'))
+            | matches!(
+                key,
+                KeyEvent {
+                    code: Char('c' | 'q'),
+                    modifiers: crossterm::event::KeyModifiers::CONTROL,
+                    ..
+                }
+            )
+        {
             self.cancel_action.cancel();
         }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -39,7 +39,6 @@ use ratatui::{
 };
 use ratatui_macros::line;
 use std::{
-    any::{Any, TypeId},
     collections::HashMap,
     io::stdout,
     sync::{Arc, OnceLock},


### PR DESCRIPTION
1. style: make the popup look prettier

2. chore(clippy): fix clippy lints

3. feat(QoL): add universal quit
3.1. `ctrl-(c|q)` exit universally now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for cancellation: Ctrl+C, Ctrl+Q, and Q.
  * Numeric keys 1–5 now enable component focusing.

* **Chores**
  * Removed unused imports and optimized event handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->