### PR TITLE
feat: add support for showing reactions without slowing down FCP

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -26,7 +26,7 @@ use crossterm::{
 use futures::{StreamExt, future::FutureExt};
 use octocrab::{
     Page,
-    models::{Label, issues::Issue},
+    models::{Label, issues::Issue, reactions::ReactionContent},
 };
 use rat_widget::{
     event::{HandleEvent, Outcome, Regular},
@@ -444,6 +444,9 @@ pub enum Action {
     IssueCommentsLoaded {
         number: u64,
         comments: Vec<CommentView>,
+    },
+    IssueReactionsLoaded {
+        reactions: HashMap<u64, Vec<(ReactionContent, u64)>>,
     },
     IssueCommentPosted {
         number: u64,


### PR DESCRIPTION
### TL;DR

Added support for displaying GitHub reactions on issue comments.

### What changed?

- Added a `reactions` field to the `CommentView` struct to store reaction data
- Implemented fetching of reactions for comments using the GitHub API
- Added a new `Action::IssueReactionsLoaded` to handle reaction data updates
- Created helper functions to display reactions in a consistent order with appropriate labels
- Added visual representation of reactions below each comment, showing emoji labels and counts