### PR TITLE
refactor!: change help to look and be much better

### DIFF
--- a/src/ui/components/help.rs
+++ b/src/ui/components/help.rs
@@ -1,24 +1,80 @@
-use ratatui::widgets::{BlockExt, Clear, Paragraph, Widget};
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span, Text},
+    widgets::{BlockExt, Clear, Widget},
+};
+use tracing::info;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelpElementKind {
+    Keybind(&'static str, &'static str),
+    Text(&'static str),
+}
+
+#[macro_export]
+macro_rules! help_keybind {
+    ($key:expr, $description:expr) => {
+        $crate::ui::components::help::HelpElementKind::Keybind($key, $description)
+    };
+}
+
+#[macro_export]
+macro_rules! help_text {
+    ($text:expr) => {
+        $crate::ui::components::help::HelpElementKind::Text($text)
+    };
+}
+
+pub fn help_elements_to_text(elements: &[HelpElementKind], width: u16) -> Text<'static> {
+    let mut lines = Vec::with_capacity(elements.len());
+    for element in elements {
+        match element {
+            HelpElementKind::Keybind(key, description) => {
+                let total_length = (key.len() + description.len()) as u16; // +1 for the space between
+                let padding = if total_length < width {
+                    width - total_length
+                } else {
+                    1 // Ensure at least one space if the content exceeds the width
+                };
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        *key,
+                        Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::raw(" ".repeat(padding as usize)),
+                    Span::raw(*description),
+                ]));
+            }
+            HelpElementKind::Text(text) => {
+                let wrapped = textwrap::wrap(text, width as usize);
+                lines.extend(wrapped.into_iter().map(|line| Line::from(line).centered()));
+            }
+        }
+    }
+    Text::from(lines)
+}
 
 /// A simple component to display help information. It can be centered within its parent area using the `set_constraints` method.
 pub struct HelpComponent<'a> {
-    contraints: [u16; 2],
-    content: Paragraph<'a>,
+    contraint: u16,
+    content: &'a [HelpElementKind],
     block: Option<ratatui::widgets::Block<'a>>,
+    width: u16,
 }
 
 impl<'a> HelpComponent<'a> {
     /// Creates a new HelpComponent with the given content.
-    pub fn new(content: Paragraph<'a>) -> Self {
+    pub fn new(content: &'a [HelpElementKind]) -> Self {
         Self {
             content,
-            contraints: [0, 0],
+            width: 0,
+            contraint: 0,
             block: None,
         }
     }
     /// Sets the constraints for centering the component. The constraints are specified as percentages of the parent area.
-    pub fn set_constraints(self, contraints: [u16; 2]) -> Self {
-        Self { contraints, ..self }
+    pub fn set_constraint(self, contraint: u16) -> Self {
+        Self { contraint, ..self }
     }
     /// Sets a block around the component. This can be used to visually separate the help content from other UI elements.
     pub fn block(self, block: ratatui::widgets::Block<'a>) -> Self {
@@ -30,19 +86,33 @@ impl<'a> HelpComponent<'a> {
 }
 
 impl<'a> Widget for HelpComponent<'a> {
-    fn render(self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
-        use ratatui::layout::Constraint::Percentage;
-        let centered_area = if self.contraints != [0, 0] {
-            area.centered(
-                Percentage(self.contraints[0]),
-                Percentage(self.contraints[1]),
-            )
+    fn render(mut self, area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
+        use ratatui::layout::Constraint::{Length, Percentage};
+        info!(content = ?self.content, "Rendering HelpComponent");
+        info!(content_length = ?self.content.len(), "Content length");
+        let mut centered_area = if self.contraint != 0 {
+            area.centered(Percentage(self.contraint), Length(self.contraint))
         } else {
             area
         };
-        let inner = self.block.inner_if_some(centered_area);
+        let mut inner = self.block.inner_if_some(centered_area);
+        self.width = inner.width;
+        let text = help_elements_to_text(self.content, self.width);
+        let text_height = text.height() as u16;
+        let y_offset = |h: u16| {
+            if text_height < h {
+                (h - text_height) / 2
+            } else {
+                0
+            }
+        };
+        inner.y += y_offset(inner.height) + 1;
+        inner.height = text.height() as u16;
+        let inner_height = inner.height;
+        centered_area.y += y_offset(centered_area.height);
+        centered_area.height = inner_height + 2;
         Clear.render(centered_area, buf);
         self.block.render(centered_area, buf);
-        self.content.render(inner, buf);
+        text.render(inner, buf);
     }
 }

--- a/src/ui/components/issue_conversation.rs
+++ b/src/ui/components/issue_conversation.rs
@@ -31,22 +31,22 @@ use crate::{
     app::GITHUB_CLIENT,
     ui::{
         Action,
-        components::{Component, issue_list::MainScreen},
+        components::{Component, help::HelpElementKind, issue_list::MainScreen},
         layout::Layout,
         utils::get_border_style,
     },
 };
 
-pub const HELP: &str = "\
-Issue Conversation Help:\n\
-- Up/Down: select issue body/comment entry\n\
-- PageUp/PageDown/Home/End: scroll message body pane\n\
-- Ctrl+P: toggle comment input/preview\n\
-- r: add reaction to selected comment\n\
-- R: remove reaction from selected comment\n\
-- Ctrl+Enter or Alt+Enter: send comment\n\
-- Esc: return to issue list screen\n\
-";
+pub const HELP: &[HelpElementKind] = &[
+    crate::help_text!("Issue Conversation Help"),
+    crate::help_keybind!("Up/Down", "select issue body/comment entry"),
+    crate::help_keybind!("PageUp/PageDown/Home/End", "scroll message body pane"),
+    crate::help_keybind!("Ctrl+P", "toggle comment input/preview"),
+    crate::help_keybind!("r", "add reaction to selected comment"),
+    crate::help_keybind!("R", "remove reaction from selected comment"),
+    crate::help_keybind!("Ctrl+Enter / Alt+Enter", "send comment"),
+    crate::help_keybind!("Esc", "return to issue list screen"),
+];
 
 #[derive(Debug, Clone)]
 pub struct IssueConversationSeed {

--- a/src/ui/components/issue_create.rs
+++ b/src/ui/components/issue_create.rs
@@ -23,7 +23,7 @@ use crate::{
     ui::{
         Action, AppState,
         components::{
-            Component,
+            Component, help::HelpElementKind,
             issue_conversation::{IssueConversationSeed, render_markdown_lines},
             issue_detail::IssuePreviewSeed,
             issue_list::MainScreen,
@@ -33,14 +33,14 @@ use crate::{
     },
 };
 
-pub const HELP: &str = "\
-Issue Create Help:\n\
-- n (from issue list): open new issue composer\n\
-- Tab / Shift+Tab: switch fields\n\
-- Ctrl+P: toggle body input and markdown preview\n\
-- Ctrl+Enter or Alt+Enter: create issue\n\
-- Esc: return to issue list\n\
-";
+pub const HELP: &[HelpElementKind] = &[
+    crate::help_text!("Issue Create Help"),
+    crate::help_keybind!("n", "open new issue composer (from issue list)"),
+    crate::help_keybind!("Tab / Shift+Tab", "switch fields"),
+    crate::help_keybind!("Ctrl+P", "toggle body input and markdown preview"),
+    crate::help_keybind!("Ctrl+Enter / Alt+Enter", "create issue"),
+    crate::help_keybind!("Esc", "return to issue list"),
+];
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 enum InputMode {

--- a/src/ui/components/issue_detail.rs
+++ b/src/ui/components/issue_detail.rs
@@ -13,13 +13,18 @@ use ratatui::{
 };
 use ratatui_macros::line;
 
-use crate::ui::{Action, AppState, components::Component, layout::Layout, utils::get_border_style};
+use crate::ui::{
+    Action, AppState,
+    components::{Component, help::HelpElementKind},
+    layout::Layout,
+    utils::get_border_style,
+};
 
-pub const HELP: &str = "\
-Issue Preview Help:\n\
-- Read-only panel showing metadata for the selected issue\n\
-- Use global focus keys (1-5) to switch to an interactive component\n\
-";
+pub const HELP: &[HelpElementKind] = &[
+    crate::help_text!("Issue Preview Help"),
+    crate::help_text!("Read-only panel showing metadata for the selected issue."),
+    crate::help_keybind!("1-6", "use global focus keys to switch components"),
+];
 
 #[derive(Debug, Clone)]
 pub struct IssuePreviewSeed {

--- a/src/ui/components/issue_list.rs
+++ b/src/ui/components/issue_list.rs
@@ -4,7 +4,8 @@ use crate::{
     ui::{
         Action, MergeStrategy,
         components::{
-            Component, issue_conversation::IssueConversationSeed, issue_detail::IssuePreviewSeed,
+            Component, help::HelpElementKind, issue_conversation::IssueConversationSeed,
+            issue_detail::IssuePreviewSeed,
         },
         layout::Layout,
         utils::get_border_style,
@@ -40,13 +41,14 @@ use tokio::sync::oneshot;
 use tracing::info;
 
 pub static LOADED_ISSUE_COUNT: AtomicU32 = AtomicU32::new(0);
-pub const HELP: &str = "\
-↑/↓: Navigate Issues
-Enter: View Issue Details
-a: Add Assignee(s)
-A: Remove Assignee(s)
-n: Create New Issue
-";
+pub const HELP: &[HelpElementKind] = &[
+    crate::help_text!("Issue List Help"),
+    crate::help_keybind!("Up/Down", "navigate issues"),
+    crate::help_keybind!("Enter", "view issue details"),
+    crate::help_keybind!("a", "add assignee(s)"),
+    crate::help_keybind!("A", "remove assignee(s)"),
+    crate::help_keybind!("n", "create new issue"),
+];
 pub struct IssueList<'a> {
     pub issues: Vec<IssueListItem>,
     pub page: Option<Arc<Page<Issue>>>,

--- a/src/ui/components/label_list.rs
+++ b/src/ui/components/label_list.rs
@@ -29,7 +29,9 @@ use tracing::error;
 use crate::{
     app::GITHUB_CLIENT,
     ui::{
-        Action, AppState, COLOR_PROFILE, components::Component, layout::Layout,
+        Action, AppState, COLOR_PROFILE,
+        components::{Component, help::HelpElementKind},
+        layout::Layout,
         utils::get_border_style,
     },
 };
@@ -37,17 +39,17 @@ use crate::{
 const MARKER: &str = ratatui::symbols::marker::DOT;
 const STATUS_TTL: Duration = Duration::from_secs(3);
 const DEFAULT_COLOR: &str = "ededed";
-pub const HELP: &str = "\
-Label List Help:\n\
-- Up/Down: select label\n\
-- a: add label to selected issue\n\
-- d: remove selected label from issue\n\
-- f: open popup label regex search\n\
-- Ctrl+I (popup): toggle case-insensitive search\n\
-- Enter: submit add/create input\n\
-- Esc: cancel current label edit flow\n\
-- y / n: confirm or cancel creating missing label\n\
-";
+pub const HELP: &[HelpElementKind] = &[
+    crate::help_text!("Label List Help"),
+    crate::help_keybind!("Up/Down", "select label"),
+    crate::help_keybind!("a", "add label to selected issue"),
+    crate::help_keybind!("d", "remove selected label from issue"),
+    crate::help_keybind!("f", "open popup label regex search"),
+    crate::help_keybind!("Ctrl+I", "toggle case-insensitive search (popup)"),
+    crate::help_keybind!("Enter", "submit add/create input"),
+    crate::help_keybind!("Esc", "cancel current label edit flow"),
+    crate::help_keybind!("y / n", "confirm or cancel creating missing label"),
+];
 
 #[derive(Debug)]
 pub struct LabelList {

--- a/src/ui/components/search_bar.rs
+++ b/src/ui/components/search_bar.rs
@@ -22,20 +22,20 @@ use crate::{
     errors::AppError,
     ui::{
         Action, AppState, MergeStrategy,
-        components::{Component, issue_list::MainScreen},
+        components::{Component, help::HelpElementKind, issue_list::MainScreen},
         layout::Layout,
         utils::{get_border_style, get_loader_area},
     },
 };
 
 const OPTIONS: [&str; 3] = ["Open", "Closed", "All"];
-pub const HELP: &str = "\
-Search Bar Help:\n\
-- Type issue text in Search\n\
-- Type labels in Search Labels (separate multiple labels with ';')\n\
-- Use Tab / Shift+Tab to move between inputs and status selector\n\
-- Enter: run search\n\
-";
+pub const HELP: &[HelpElementKind] = &[
+    crate::help_text!("Search Bar Help"),
+    crate::help_keybind!("Type", "issue text in Search"),
+    crate::help_keybind!("Type", "labels in Search Labels (separate multiple with ';')"),
+    crate::help_keybind!("Tab / Shift+Tab", "move between inputs and status selector"),
+    crate::help_keybind!("Enter", "run search"),
+];
 
 pub struct TextSearch {
     search_state: rat_widget::text_input::TextInputState,


### PR DESCRIPTION
I changed HELP from just an &'static str to an &[HelpElementKind]. This
allows us to represent both text and keybind pairs. I also changed the
helpbox location calculation to render a compact one based on the text
height