### PR TITLE
feat: fix the text area paste in Issue Conversation and Issue Create

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,4 +24,4 @@ pub enum AppError {
     Other(#[from] anyhow::Error),
 }
 
-pub type Result<T> = std::result::Result<T, AppError>;
+pub type Result<T, E = AppError> = std::result::Result<T, E>;

--- a/src/ui/components/issue_conversation.rs
+++ b/src/ui/components/issue_conversation.rs
@@ -1315,6 +1315,18 @@ impl Component for IssueConversation {
                                 .map_err(|_| AppError::TokioMpsc)?;
                         }
                     }
+                    event::Event::Paste(p) if self.input_state.is_focused() => {
+                        self.input_state.insert_str(p);
+                        let action_tx = self.action_tx.as_ref().ok_or_else(|| {
+                            AppError::Other(anyhow!(
+                                "issue conversation action channel unavailable"
+                            ))
+                        })?;
+                        action_tx
+                            .send(Action::ForceRender)
+                            .await
+                            .map_err(|_| AppError::TokioMpsc)?;
+                    }
                     _ => {}
                 }
                 self.body_paragraph_state

--- a/src/ui/components/issue_create.rs
+++ b/src/ui/components/issue_create.rs
@@ -407,6 +407,9 @@ impl Component for IssueCreate {
                         {
                             return Ok(());
                         }
+                        if let event::Event::Paste(pasted_stuff) = event {
+                            self.body_state.insert_str(pasted_stuff);
+                        }
                         let o = self.body_state.handle(event, rat_widget::event::Regular);
                         if o == TextOutcome::TextChanged {
                             let action_tx = self.action_tx.as_ref().ok_or_else(|| {


### PR DESCRIPTION
Closes #39

- Enables bracketed paste and handles `Paste` event by appending the pasted content to the `TextArea`. 
- Also cleans up the setup and teardown of additional terminal settings like the bracketed paste.
- Adds a new panic hook that properly tears down the self-added attributes.
