### PR TITLE
feat: add support for quoting messages

### DIFF
--- a/KEYBINDS.md
+++ b/KEYBINDS.md
@@ -29,6 +29,7 @@
 - `e` - edit selected comment in external editor
 - `r` - add reaction to selected comment
 - `R` - remove reaction from selected comment
+- `>` - quote selected comment in comment input
 - `Ctrl+Enter / Alt+Enter` - send comment
 - `Esc` - exit fullscreen (if active) or return to issue list
 

--- a/src/ui/components/issue_conversation.rs
+++ b/src/ui/components/issue_conversation.rs
@@ -1280,6 +1280,26 @@ impl Component for IssueConversation {
                         return Ok(());
                     }
 
+                    ct_event!(key press '>')
+                        if self.list_state.is_focused()
+                            || self.body_paragraph_state.is_focused() =>
+                    {
+                        if let Some(comment) = self.selected_comment() {
+                            let comment_body = comment.body.as_ref();
+                            let quoted = comment_body
+                                .lines()
+                                .map(|line| format!("> {}", line.trim()))
+                                .collect::<Vec<_>>()
+                                .join("\n");
+                            self.input_state.insert_str(&quoted);
+                            self.input_state.insert_newline();
+                            self.input_state.move_to_end(false);
+                            self.input_state.move_to_line_end(false);
+                            self.input_state.focus.set(true);
+                            self.list_state.focus.set(false);
+                        }
+                    }
+
                     event::Event::Key(key) if key.code != event::KeyCode::Tab => {
                         let o = self.input_state.handle(event, rat_widget::event::Regular);
                         let o2 = self


### PR DESCRIPTION
### TL;DR

Added ability to quote selected comments in the comment input using the `>` key.

### What changed?

- Added a new keybinding `>` that quotes the currently selected comment in the comment input
- When pressed, the selected comment's text is formatted with `>` at the beginning of each line
- The quoted text is inserted into the comment input, and focus is moved to the input field
- Updated KEYBINDS.md to document the new functionality