### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/JayanAXHF/gitv/compare/gitv-tui-v0.1.1...gitv-tui-v0.1.2) - 2026-02-19
+
+### Other
+
+- *(readme)* add badges for version and ratatui
+
 ## [0.1.1](https://github.com/JayanAXHF/gitv/compare/gitv-tui-v0.1.0...gitv-tui-v0.1.1) - 2026-02-19
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "gitv-tui"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "hyperrat"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ratatui-core",
  "textwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitv-tui"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 build = "build.rs"
 description = "A terminal-based GitHub client built with Rust and Ratatui."
@@ -26,7 +26,7 @@ crossterm = { version = "0.29.0", features = ["event-stream"] }
 directories = "6.0.0"
 edit = "0.1.5"
 futures = "0.3.31"
-hyperrat = { path = "crates/hyperrat", version = "0.1.0" }
+hyperrat = { path = "crates/hyperrat", version = "0.1.1" }
 inquire = "0.9.3"
 keyring = { version = "3.6.3", features = ["apple-native", "windows-native", "linux-native"] }
 octocrab = "0.49.5"

--- a/crates/hyperrat/CHANGELOG.md
+++ b/crates/hyperrat/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/JayanAXHF/gitv/compare/hyperrat-v0.1.0...hyperrat-v0.1.1) - 2026-02-19
+
+### Other
+
+- *(hyperrat)* fix the source URL in hyperrat's cargo.toml

--- a/crates/hyperrat/Cargo.toml
+++ b/crates/hyperrat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hyperrat"
 description = "An OSC 8 link widget for ratatui that doesn't break your UI"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["JayanAXHF <sunil.chdry@gmail.com>"]
 license = "Unlicense OR MIT"


### PR DESCRIPTION



## 🤖 New release

* `hyperrat`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `gitv-tui`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `hyperrat`

<blockquote>

## [0.1.1](https://github.com/JayanAXHF/gitv/compare/hyperrat-v0.1.0...hyperrat-v0.1.1) - 2026-02-19

### Other

- *(hyperrat)* fix the source URL in hyperrat's cargo.toml
</blockquote>

## `gitv-tui`

<blockquote>

## [0.1.2](https://github.com/JayanAXHF/gitv/compare/gitv-tui-v0.1.1...gitv-tui-v0.1.2) - 2026-02-19

### Other

- *(readme)* add badges for version and ratatui
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).