### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "gitv-tui"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4341,7 +4341,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-toaster"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitv-tui"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 build = "build.rs"
 description = "A terminal-based GitHub client built with Rust and Ratatui."
@@ -39,7 +39,7 @@ rat-cursor = "2.0.0"
 rat-widget = "3.2.1"
 ratatui = {version = "0.30.0", features = ["unstable-widget-ref"] }
 ratatui-macros = "0.7.0"
-ratatui-toaster = { path = "crates/ratatui-toaster", version = "0.1.2", features = ["tokio"] }
+ratatui-toaster = { path = "crates/ratatui-toaster", version = "0.1.3", features = ["tokio"] }
 termprofile = { version = "0.2.2", features = ["convert", "ratatui"] }
 textwrap = { version = "0.16.2", features = ["terminal_size"] }
 thiserror = "2.0.18"

--- a/crates/ratatui-toaster/Cargo.toml
+++ b/crates/ratatui-toaster/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ratatui-toaster"
 description = "An extremely lightweight toast engine for ratatui"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 authors = ["JayanAXHF <sunil.chdry@gmail.com>"]
 license = "Unlicense OR MIT"


### PR DESCRIPTION



## 🤖 New release

* `ratatui-toaster`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `gitv-tui`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `ratatui-toaster`

<blockquote>

## [0.1.1](https://github.com/JayanAXHF/gitv/compare/ratatui-toaster-v0.1.0...ratatui-toaster-v0.1.1) - 2026-02-22

### Other

- *(gitv-tui)* release v0.3.0
</blockquote>

## `gitv-tui`

<blockquote>

## [0.4.2](https://github.com/JayanAXHF/gitv/compare/gitv-tui-v0.4.1...gitv-tui-v0.4.2) - 2026-03-31

### <!-- 1 -->Bug Fixes

- Fixed issue body not being editable and not having reactions

### <!-- 10 -->Other

- bump flake.lock
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).