### PR TITLE
ops: Add nix to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I'm thinking of creating a workflow that triggers a `nix build` on dependabot branches to make sure package builds whenever a lock update happens, is this fine? 