### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/JayanAXHF/gitv/compare/gitv-tui-v0.4.3...gitv-tui-v0.4.4) - 2026-06-28
+
+### <!-- 1 -->Bug Fixes
+
+- *(ops)* fixed bech workflow not finding keyring and dbus
+- fix external editor lagging a lot
+- nix packaging
+
+### <!-- 10 -->Other
+
+- hyperrat fix: upgrade to ratatui 0.30
+- add nix.yml
+- *(benchmarks)* add bencher regression tracking
+- Add nix to dependabot.yml
+- *(benchmarks)* add bencher regression tracking
+
 ## [0.4.3](https://github.com/JayanAXHF/gitv/compare/gitv-tui-v0.4.2...gitv-tui-v0.4.3) - 2026-04-19
 
 ### <!-- 10 -->Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "gitv-tui"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "hyperrat"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "ratatui-core",
  "textwrap",
@@ -4437,7 +4437,7 @@ dependencies = [
 
 [[package]]
 name = "ratatui-toaster"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitv-tui"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 build = "build.rs"
 description = "A terminal-based GitHub client built with Rust and Ratatui."
@@ -29,7 +29,7 @@ crossterm = { version = "0.29.0", features = ["event-stream"] }
 directories = "6.0.0"
 edit = "0.1.5"
 futures = "0.3.32"
-hyperrat = { path = "crates/hyperrat", version = "0.1.1" }
+hyperrat = { path = "crates/hyperrat", version = "0.1.2" }
 inquire = "0.9.4"
 keyring = { version = "3.6.3", features = ["apple-native", "windows-native"] }
 octocrab = "0.49.7"
@@ -39,7 +39,7 @@ rat-cursor = "2.0.0"
 rat-widget = "3.2.1"
 ratatui = {version = "0.30.0", features = ["unstable-widget-ref"] }
 ratatui-macros = "0.7.0"
-ratatui-toaster = { path = "crates/ratatui-toaster", version = "0.1.3", features = ["tokio"] }
+ratatui-toaster = { path = "crates/ratatui-toaster", version = "0.1.4", features = ["tokio"] }
 termprofile = { version = "0.2.3", features = ["convert", "ratatui"] }
 textwrap = { version = "0.16.2", features = ["terminal_size"] }
 thiserror = "2.0.18"

--- a/crates/hyperrat/CHANGELOG.md
+++ b/crates/hyperrat/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/JayanAXHF/gitv/compare/hyperrat-v0.1.1...hyperrat-v0.1.2) - 2026-06-28
+
+### <!-- 10 -->Other
+
+- hyperrat fix: upgrade to ratatui 0.30
+
 ## [0.1.1](https://github.com/JayanAXHF/gitv/compare/hyperrat-v0.1.0...hyperrat-v0.1.1) - 2026-02-19
 
 ### Other

--- a/crates/hyperrat/Cargo.toml
+++ b/crates/hyperrat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hyperrat"
 description = "An OSC 8 link widget for ratatui that doesn't break your UI"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["JayanAXHF <sunil.chdry@gmail.com>"]
 license = "Unlicense OR MIT"

--- a/crates/ratatui-toaster/Cargo.toml
+++ b/crates/ratatui-toaster/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ratatui-toaster"
 description = "An extremely lightweight toast engine for ratatui"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 authors = ["JayanAXHF <sunil.chdry@gmail.com>"]
 license = "Unlicense OR MIT"


### PR DESCRIPTION



## 🤖 New release

* `hyperrat`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `ratatui-toaster`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `gitv-tui`: 0.4.3 -> 0.4.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `hyperrat`

<blockquote>

## [0.1.2](https://github.com/JayanAXHF/gitv/compare/hyperrat-v0.1.1...hyperrat-v0.1.2) - 2026-06-28

### <!-- 10 -->Other

- hyperrat fix: upgrade to ratatui 0.30
</blockquote>

## `ratatui-toaster`

<blockquote>

## [0.1.1](https://github.com/JayanAXHF/gitv/compare/ratatui-toaster-v0.1.0...ratatui-toaster-v0.1.1) - 2026-02-22

### Other

- *(gitv-tui)* release v0.3.0
</blockquote>

## `gitv-tui`

<blockquote>

## [0.4.4](https://github.com/JayanAXHF/gitv/compare/gitv-tui-v0.4.3...gitv-tui-v0.4.4) - 2026-06-28

### <!-- 1 -->Bug Fixes

- *(ops)* fixed bech workflow not finding keyring and dbus
- fix external editor lagging a lot
- nix packaging

### <!-- 10 -->Other

- hyperrat fix: upgrade to ratatui 0.30
- add nix.yml
- *(benchmarks)* add bencher regression tracking
- Add nix to dependabot.yml
- *(benchmarks)* add bencher regression tracking
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).