### PR TITLE
ops: add nix.yml

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,18 @@
+name: Nix CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  nix:
+    runs-on: ubuntu-latest
+
+    steps:   
+      - uses: actions/checkout@v6
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+      - name: Check flake
+        run: nix flake check


### PR DESCRIPTION
Helps checking whether changes to nix related files evaluate correctly.

There's no `nix build` step because it is a waste imo, `build.yml` already checks if the package builds and a `nix build` step would be doing the same but instead using nix.